### PR TITLE
updates for Ember CLI

### DIFF
--- a/assets/javascripts/discourse/initializers/guest-gate.js.es6
+++ b/assets/javascripts/discourse/initializers/guest-gate.js.es6
@@ -1,6 +1,7 @@
 import { startPageTracking } from 'discourse/lib/page-tracker';
 import { viewTrackingRequired } from 'discourse/lib/ajax';
 import showGate from 'discourse/plugins/guest-gate/discourse/lib/show-gate';
+import User from "discourse/models/user";
 var botPattern = "(googlebot\/|Googlebot-Mobile|Googlebot-Image|Google favicon|Mediapartners-Google|bingbot|slurp|java|wget|curl|Commons-HttpClient|Python-urllib|libwww|httpunit|nutch|phpcrawl|msnbot|jyxobot|FAST-WebCrawler|FAST Enterprise Crawler|biglotron|teoma|convera|seekbot|gigablast|exabot|ngbot|ia_archiver|GingerCrawler|webmon |httrack|webcrawler|grub.org|UsineNouvelleCrawler|antibot|netresearchserver|speedy|fluffy|bibnum.bnf|findlink|msrbot|panscient|yacybot|AISearchBot|IOI|ips-agent|tagoobot|MJ12bot|dotbot|woriobot|yanga|buzzbot|mlbot|yandexbot|purebot|Linguee Bot|Voyager|CyberPatrol|voilabot|baiduspider|citeseerxbot|spbot|twengabot|postrank|turnitinbot|scribdbot|page2rss|sitebot|linkdex|Adidxbot|blekkobot|ezooms|dotbot|Mail.RU_Bot|discobot|heritrix|findthatfile|europarchive.org|NerdByNature.Bot|sistrix crawler|ahrefsbot|Aboundex|domaincrawler|wbsearchbot|summify|ccbot|edisterbot|seznambot|ec2linkfinder|gslfbot|aihitbot|intelium_bot|facebookexternalhit|yeti|RetrevoPageAnalyzer|lb-spider|sogou|lssbot|careerbot|wotbox|wocbot|ichiro|DuckDuckBot|lssrocketcrawler|drupact|webcompanycrawler|acoonbot|openindexspider|gnam gnam spider|web-archive-net.com.bot|backlinkcrawler|coccoc|integromedb|content crawler spider|toplistbot|seokicks-robot|it2media-domain-crawler|ip-web-crawler.com|siteexplorer.info|elisabot|proximic|changedetection|blexbot|arabot|WeSEE:Search|niki-bot|CrystalSemanticsBot|rogerbot|360Spider|psbot|InterfaxScanBot|Lipperhey SEO Service|CC Metadata Scaper|g00g1e.net|GrapeshotCrawler|urlappendbot|brainobot|fr-crawler|binlar|SimpleCrawler|Livelapbot|Twitterbot|cXensebot|smtbot|bnf.fr_bot|A6-Indexer|ADmantX|Facebot|Twitterbot|OrangeBot|memorybot|AdvBot|MegaIndex|SemanticScholarBot|ltx71|nerdybot|xovibot|BUbiNG|Qwantify|archive.org_bot|Applebot|TweetmemeBot|crawler4j|findxbot|SemrushBot|yoozBot|lipperhey|y!j-asr|Domain Re-Animator Bot|AddThis)";
 
 export default {
@@ -8,8 +9,9 @@ export default {
   after: 'inject-objects',
 
   initialize(container) {
-    if(Discourse.SiteSettings.guest_gate_enabled) {
-      if (!Discourse.User.current()) {
+    const siteSettings = container.lookup("site-settings:main");
+    if(siteSettings.guest_gate_enabled) {
+      if (!User.current()) {
         var pageView = 0;
         // Tell our AJAX system to track a page transition
         const router = container.lookup('router:main');


### PR DESCRIPTION
Here are a couple of changes that I think are needed for EmberCLI. One of them is causing a deprecation.

https://meta.discourse.org/t/moving-away-from-discourse-sitesettings-an-upgrading-guide/158977 is where I got the notion for the siteSettings. The User bit I got somewhere else, but that's what's causing the deprecation warning that I see, and I'm pretty sure that method is working on a plugin of mine.

This is not tested, just typed into the github edit window, so please don't think that it works.

Hopefully it'll help.